### PR TITLE
feat: side-by-side split diff view

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	TabWidth        int    `json:"tab_width"`
 	CommitMsgCmd    string `json:"commit_msg_cmd"`
 	CommitMsgPrompt string `json:"commit_msg_prompt"`
+	SplitDiff       bool   `json:"split_diff"`
 }
 
 // Default returns the default configuration.


### PR DESCRIPTION
## Summary
- `v` key toggles between unified and side-by-side diff view in both file list and diff modes
- Old file on left panel, new file on right panel, separated by `│`
- Auto-fallback to unified when terminal width < 60 chars
- Preference persisted in config (`split_diff`)
- Same syntax highlighting and styles in both layouts

Closes #6

## Test plan
- [ ] `v` toggles split/unified in file list and diff modes
- [ ] Context lines appear on both sides, removed left-only, added right-only
- [ ] Syntax highlighting works on both panels
- [ ] Hunk headers span full width
- [ ] Untracked files show all-added on right
- [ ] Narrow terminal auto-falls back to unified
- [ ] Preference persists across restarts (`~/.config/differ/config.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)